### PR TITLE
fix: corrigir erros e inconsistencias no dashboard Green Village

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,1123 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Green Village • Dashboard de Importação</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { sans: ['DM Sans', 'sans-serif'], mono: ['JetBrains Mono', 'monospace'] },
+          colors: {
+            gv: { bg: '#05070b', card: '#0b0f17', soft: '#101521', accent: '#00ff88', blue: '#4da6ff', border: 'rgba(255,255,255,0.08)' }
+          }
+        }
+      }
+    };
+  </script>
+  <style>
+    ::-webkit-scrollbar { width: 6px; }
+    ::-webkit-scrollbar-track { background: #0b0f17; }
+    ::-webkit-scrollbar-thumb { background: #1e293b; border-radius: 3px; }
+    ::-webkit-scrollbar-thumb:hover { background: #334155; }
+    body { background: radial-gradient(ellipse at top, #141b2c 0%, #05070b 55%); }
+    .glow-green { box-shadow: 0 0 20px rgba(0,255,136,0.25), 0 0 60px rgba(0,255,136,0.08); }
+    .glow-green-sm { box-shadow: 0 0 10px rgba(0,255,136,0.2); }
+    .tab-active { border-color: #00ff88 !important; color: #00ff88 !important; background: rgba(0,255,136,0.08) !important; }
+    .country-active { border-color: rgba(0,255,136,0.5) !important; color: #00ff88 !important; box-shadow: 0 0 12px rgba(0,255,136,0.3); }
+    .result-highlight { border-color: rgba(0,255,136,0.4) !important; background: radial-gradient(circle at top left, rgba(0,255,136,0.12), #060910) !important; }
+    input[type="number"]::-webkit-inner-spin-button { opacity: 0.3; }
+    select { appearance: none; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%239ca2b8' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 8px center; padding-right: 28px !important; }
+    .fade-in { animation: fadeIn 0.3s ease-out; }
+    @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+    @keyframes pulse-glow { 0%, 100% { box-shadow: 0 0 8px rgba(0,255,136,0.2); } 50% { box-shadow: 0 0 18px rgba(0,255,136,0.5); } }
+    .pulse-rate { animation: pulse-glow 2s ease-in-out infinite; }
+    @media print { body { background: #fff !important; color: #000 !important; } }
+  </style>
+</head>
+<body class="min-h-screen text-gray-200 font-sans">
+<div id="app" class="max-w-[1400px] mx-auto px-4 py-5">
+
+  <!-- HEADER -->
+  <header class="relative overflow-hidden rounded-2xl border border-white/[.08] p-5 mb-5" style="background: radial-gradient(circle at top left, rgba(0,255,136,0.1), transparent 55%), radial-gradient(circle at top right, rgba(77,166,255,0.1), transparent 55%), linear-gradient(135deg, rgba(255,255,255,0.03), rgba(7,10,18,0.98)); box-shadow: 0 18px 45px rgba(0,0,0,0.6);">
+    <div class="flex flex-wrap items-center gap-4 relative z-10">
+      <div class="flex-1 min-w-[200px]">
+        <h1 class="text-2xl md:text-3xl font-bold tracking-wide uppercase flex flex-wrap items-baseline gap-3">
+          <span class="text-[#00ff88]" style="text-shadow: 0 0 14px rgba(0,255,136,0.5);">Green Village</span>
+          <span class="text-base text-gray-400 normal-case tracking-normal">Dashboard de Importação</span>
+        </h1>
+        <p class="text-gray-500 text-sm mt-1">Calculadora unificada • Margens automáticas • Câmbio em tempo real • Exportação PDF</p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <span class="px-3 py-1 rounded-full border border-[#00ff88]/30 text-[#00ff88] text-xs uppercase tracking-widest bg-black/50">v3.1 — 2025</span>
+        <span id="rateStatus" class="px-3 py-1 rounded-full border border-white/10 text-gray-500 text-xs uppercase tracking-widest bg-black/50">Câmbio: offline</span>
+      </div>
+    </div>
+  </header>
+
+  <!-- TABS -->
+  <nav class="flex flex-wrap gap-2 mb-5">
+    <button onclick="GV.switchTab('international')" id="tab-international" class="tab-active px-5 py-2.5 rounded-xl border border-white/10 bg-gv-card text-sm font-semibold uppercase tracking-wider text-gray-400 transition-all hover:border-white/20">
+      🌍 Internacional
+    </button>
+    <button onclick="GV.switchTab('brazil')" id="tab-brazil" class="px-5 py-2.5 rounded-xl border border-white/10 bg-gv-card text-sm font-semibold uppercase tracking-wider text-gray-400 transition-all hover:border-white/20">
+      🇧🇷 Brasil Detalhada
+    </button>
+    <button onclick="GV.switchTab('settings')" id="tab-settings" class="px-5 py-2.5 rounded-xl border border-white/10 bg-gv-card text-sm font-semibold uppercase tracking-wider text-gray-400 transition-all hover:border-white/20">
+      ⚙️ Configurações
+    </button>
+  </nav>
+
+  <!-- ================================================================== -->
+  <!-- TAB 1: INTERNACIONAL -->
+  <!-- ================================================================== -->
+  <div id="panel-international" class="fade-in">
+    <div class="grid grid-cols-1 lg:grid-cols-[260px_1fr] gap-4">
+
+      <!-- SIDEBAR: PAÍSES -->
+      <aside class="bg-gv-card/95 rounded-2xl border border-white/[.06] p-4" style="box-shadow: 0 12px 35px rgba(0,0,0,0.5);">
+        <h2 class="text-xs uppercase tracking-[0.16em] text-gray-500 mb-3 font-semibold">País de destino</h2>
+
+        <p class="text-[11px] text-gray-600 uppercase tracking-widest mb-1">União Europeia</p>
+        <div class="grid grid-cols-2 gap-1.5" id="eu-countries"></div>
+
+        <p class="text-[11px] text-gray-600 uppercase tracking-widest mt-3 mb-1">Fora da UE</p>
+        <div class="grid grid-cols-2 gap-1.5" id="non-eu-countries"></div>
+
+        <p class="text-[10px] text-gray-600 mt-4 leading-relaxed">
+          1) Escolhe o destino &nbsp;→&nbsp; 2) Origem &nbsp;→&nbsp; 3) Preço da casa.<br>
+          A escala (Low / Médio / Luxo) é detectada automaticamente.
+        </p>
+      </aside>
+
+      <!-- MAIN CALC -->
+      <section class="bg-gv-card/95 rounded-2xl border border-white/[.06] p-5" style="box-shadow: 0 12px 35px rgba(0,0,0,0.5);">
+        <!-- Top info -->
+        <div class="flex flex-wrap items-center gap-3 mb-3">
+          <div class="flex items-center gap-2 text-base font-semibold">
+            <span class="text-xl" id="intl_flag">🇵🇹</span>
+            <span>Simulação para</span>
+            <span class="text-gray-400 font-normal" id="intl_countryLabel">Portugal</span>
+          </div>
+          <div class="ml-auto flex items-center gap-2 px-3 py-1 rounded-full border border-white/10 bg-gv-bg text-sm">
+            <span class="text-[10px] uppercase tracking-widest text-gray-500">Escala</span>
+            <span class="px-2 py-0.5 rounded-full text-xs font-bold text-gv-bg" style="background: linear-gradient(135deg, #00ff88, #4da6ff);" id="intl_tierPill">Valor Médio</span>
+          </div>
+        </div>
+        <p class="text-xs text-gray-500 mb-4" id="intl_tierDesc">Low Budget até 5.000€, Luxo acima de 20.000€.</p>
+
+        <!-- Inputs -->
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div>
+            <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1 font-medium">Preço de compra</label>
+            <div class="flex gap-2">
+              <input type="number" id="intl_price" placeholder="Ex: 15000" min="0" class="flex-1 rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 focus:ring-1 focus:ring-[#00ff88]/20 transition" />
+              <select id="intl_currency" class="min-w-[88px] rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition">
+                <option value="EUR">€ EUR</option>
+                <option value="GBP">£ GBP</option>
+                <option value="BRL">R$ BRL</option>
+                <option value="CNY">¥ CNY</option>
+                <option value="USD">$ USD</option>
+                <option value="PLN">zł PLN</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1 font-medium">País de origem</label>
+            <select id="intl_origin" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition"></select>
+          </div>
+          <div>
+            <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1 font-medium">Rota marítima</label>
+            <select id="intl_route" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition"></select>
+          </div>
+        </div>
+
+        <button onclick="GV.calcInternational()" class="mt-4 w-full py-2.5 rounded-xl text-sm font-bold uppercase tracking-wider text-gv-bg transition-all hover:-translate-y-0.5" style="background: linear-gradient(135deg, #00ff88, #4da6ff); box-shadow: 0 10px 30px rgba(0,255,136,0.3);">
+          Calcular preço final
+        </button>
+
+        <p class="text-[11px] text-gray-600 mt-2">
+          Lógica: total obrigatório SEM IVA (casa + marítimo/terrestre + impostos + lucro + comissão), depois aplica IVA final.
+        </p>
+
+        <!-- Results -->
+        <div id="intl_results" class="hidden mt-5 pt-5 border-t border-white/[.06] fade-in">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="text-xs uppercase tracking-[0.14em] text-gray-500 font-semibold">Resumo Financeiro</h3>
+            <button onclick="GV.exportPDF('intl_results','Internacional')" class="px-3 py-1 rounded-lg border border-white/10 bg-gv-bg text-[11px] uppercase tracking-wider text-gray-400 hover:border-[#00ff88]/30 hover:text-[#00ff88] transition">📄 Gerar PDF</button>
+          </div>
+          <div id="intl_grid" class="grid grid-cols-1 sm:grid-cols-2 gap-2"></div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <!-- ================================================================== -->
+  <!-- TAB 2: BRASIL DETALHADA -->
+  <!-- ================================================================== -->
+  <div id="panel-brazil" class="hidden fade-in">
+    <div class="bg-gv-card/95 rounded-2xl border border-white/[.06] p-5" style="box-shadow: 0 12px 35px rgba(0,0,0,0.5);">
+      <h2 class="text-lg font-bold mb-1">Calculadora Detalhada — Containers/Mobile Homes Novos (China → Brasil)</h2>
+      <p class="text-xs text-gray-500 mb-5">Cálculo completo com todos os tributos brasileiros: II, IPI, PIS, COFINS, ICMS (gross-up).</p>
+
+      <!-- Seção 1: USD -->
+      <div class="flex items-center gap-2 mb-3">
+        <div class="w-1 h-5 rounded bg-[#00ff88]"></div>
+        <h3 class="text-sm font-semibold uppercase tracking-wider text-gray-300">1. Dados em USD (China)</h3>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">FOB (USD)</label>
+          <input type="text" id="br_fobUsd" value="8000" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+          <span class="text-[10px] text-gray-600">Preço unitário sem frete</span>
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">Frete Marítimo (USD)</label>
+          <input type="text" id="br_freightUsd" value="2500" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+          <span class="text-[10px] text-gray-600">China → Brasil</span>
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">Seguro (USD)</label>
+          <input type="text" id="br_insuranceUsd" value="0" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+          <span class="text-[10px] text-gray-600">Opcional</span>
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">Câmbio (BRL / USD)</label>
+          <input type="text" id="br_exchangeRate" value="6" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+          <span class="text-[10px] text-gray-600">1 USD = R$ X</span>
+        </div>
+      </div>
+
+      <!-- Seção 2: Fiscais -->
+      <div class="flex items-center gap-2 mb-3">
+        <div class="w-1 h-5 rounded bg-[#4da6ff]"></div>
+        <h3 class="text-sm font-semibold uppercase tracking-wider text-gray-300">2. Parâmetros Fiscais (Brasil)</h3>
+      </div>
+      <label class="flex items-center gap-2 mb-3 cursor-pointer">
+        <input type="checkbox" id="br_isBk" checked class="w-4 h-4 rounded border-gray-600 bg-gv-bg text-[#00ff88] focus:ring-[#00ff88]/30 accent-[#00ff88]" />
+        <span class="text-sm font-medium">NCM 9406.90.20 — BK (Bem de Capital) — II = 0%</span>
+      </label>
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">II (BK) %</label>
+          <input type="text" id="br_iiRateBk" value="0" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">II (não-BK) %</label>
+          <input type="text" id="br_iiRateNonBk" value="12,6" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">IPI %</label>
+          <input type="text" id="br_ipiRate" value="0" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">PIS %</label>
+          <input type="text" id="br_pisRate" value="2,1" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">COFINS %</label>
+          <input type="text" id="br_cofinsRate" value="9,65" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">ICMS %</label>
+          <input type="text" id="br_icmsRate" value="18" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+        </div>
+      </div>
+
+      <!-- Seção 3: Custos BR -->
+      <div class="flex items-center gap-2 mb-3">
+        <div class="w-1 h-5 rounded bg-amber-400"></div>
+        <h3 class="text-sm font-semibold uppercase tracking-wider text-gray-300">3. Custos no Brasil</h3>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-5">
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">Custos Portuários (BRL)</label>
+          <input type="text" id="br_portCosts" value="5500" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+          <span class="text-[10px] text-gray-600">THC, armazenagem, despachante</span>
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">Transporte Terrestre (BRL)</label>
+          <input type="text" id="br_inlandTransport" value="5000" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+          <span class="text-[10px] text-gray-600">Porto → destino final</span>
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">Mark-up / Lucro (%)</label>
+          <input type="text" id="br_marginPercent" value="30" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition" />
+        </div>
+      </div>
+
+      <button onclick="GV.calcBrazil()" class="w-full py-2.5 rounded-xl text-sm font-bold uppercase tracking-wider text-gv-bg transition-all hover:-translate-y-0.5" style="background: linear-gradient(135deg, #00ff88, #4da6ff); box-shadow: 0 10px 30px rgba(0,255,136,0.3);">
+        Calcular
+      </button>
+
+      <!-- Results Brasil -->
+      <div id="br_results" class="hidden mt-5 pt-5 border-t border-white/[.06] fade-in">
+        <div class="flex items-center justify-between mb-3">
+          <h3 class="text-xs uppercase tracking-[0.14em] text-gray-500 font-semibold">Resultado</h3>
+          <button onclick="GV.exportPDF('br_results','Brasil_Detalhada')" class="px-3 py-1 rounded-lg border border-white/10 bg-gv-bg text-[11px] uppercase tracking-wider text-gray-400 hover:border-[#00ff88]/30 hover:text-[#00ff88] transition">📄 Gerar PDF</button>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <!-- Import summary -->
+          <div class="rounded-xl border border-white/[.06] bg-gv-soft/50 p-4">
+            <h4 class="text-xs uppercase tracking-widest text-gray-500 font-semibold mb-3">Resumo da Importação</h4>
+            <div id="br_importSummary"></div>
+          </div>
+          <!-- Price formation -->
+          <div class="rounded-xl border border-white/[.06] bg-gv-soft/50 p-4">
+            <h4 class="text-xs uppercase tracking-widest text-gray-500 font-semibold mb-3">Formação de Preço</h4>
+            <div id="br_priceFormation"></div>
+          </div>
+        </div>
+      </div>
+
+      <p class="text-[10px] text-gray-600 mt-4 leading-relaxed">
+        <strong>Nota:</strong> PIS e COFINS sobre base ≈ CIF + II + IPI. ICMS com gross-up: base = (CIF + II + IPI + PIS + COFINS) / (1 − alíquota). Valores estimativos.
+      </p>
+    </div>
+  </div>
+
+  <!-- ================================================================== -->
+  <!-- TAB 3: CONFIGURAÇÕES -->
+  <!-- ================================================================== -->
+  <div id="panel-settings" class="hidden fade-in">
+    <div class="bg-gv-card/95 rounded-2xl border border-white/[.06] p-5" style="box-shadow: 0 12px 35px rgba(0,0,0,0.5);">
+      <h2 class="text-lg font-bold mb-1">Configurações Globais</h2>
+      <p class="text-xs text-gray-500 mb-5">Altera aqui os valores padrão. Estas configurações aplicam-se a todas as calculadoras.</p>
+
+      <!-- Exchange rates -->
+      <div class="flex items-center gap-2 mb-3">
+        <div class="w-1 h-5 rounded bg-[#00ff88]"></div>
+        <h3 class="text-sm font-semibold uppercase tracking-wider text-gray-300">Taxas de Câmbio (1 EUR =)</h3>
+        <button onclick="GV.fetchRates()" class="ml-auto px-3 py-1 rounded-lg border border-[#00ff88]/20 text-[11px] text-[#00ff88] uppercase tracking-wider hover:bg-[#00ff88]/10 transition">🔄 Atualizar Online</button>
+      </div>
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">GBP (£)</label>
+          <input type="text" id="cfg_gbp" value="0.84" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition font-mono" />
+          <span class="text-[10px] text-gray-600">1€ = £X</span>
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">BRL (R$)</label>
+          <input type="text" id="cfg_brl" value="6.50" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition font-mono" />
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">CNY (¥)</label>
+          <input type="text" id="cfg_cny" value="8.00" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition font-mono" />
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">USD ($)</label>
+          <input type="text" id="cfg_usd" value="1.10" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition font-mono" />
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">PLN (zł)</label>
+          <input type="text" id="cfg_pln" value="4.50" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition font-mono" />
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">USD/BRL</label>
+          <input type="text" id="cfg_usdbrl" value="6.00" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 outline-none focus:border-[#00ff88]/40 transition font-mono" />
+          <span class="text-[10px] text-gray-600">Para a aba Brasil</span>
+        </div>
+      </div>
+
+      <!-- Tier config -->
+      <div class="flex items-center gap-2 mb-3">
+        <div class="w-1 h-5 rounded bg-[#4da6ff]"></div>
+        <h3 class="text-sm font-semibold uppercase tracking-wider text-gray-300">Escalas de Margem (Tiers)</h3>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6">
+        <!-- Low -->
+        <div class="rounded-xl border border-white/[.06] bg-gv-soft/50 p-4">
+          <h4 class="text-sm font-semibold text-[#00ff88] mb-2">Low Budget <span class="text-gray-500 font-normal">(até 5.000€)</span></h4>
+          <div class="grid grid-cols-2 gap-2">
+            <div><label class="text-[10px] text-gray-500">Lucro GV (€)</label><input type="text" id="cfg_low_profit" value="3000" class="w-full rounded border border-white/10 bg-gv-bg text-white text-xs px-2 py-1.5 font-mono" /></div>
+            <div><label class="text-[10px] text-gray-500">Comissão (€)</label><input type="text" id="cfg_low_comm" value="500" class="w-full rounded border border-white/10 bg-gv-bg text-white text-xs px-2 py-1.5 font-mono" /></div>
+          </div>
+        </div>
+        <!-- Medium -->
+        <div class="rounded-xl border border-white/[.06] bg-gv-soft/50 p-4">
+          <h4 class="text-sm font-semibold text-[#4da6ff] mb-2">Valor Médio <span class="text-gray-500 font-normal">(5k–20k€)</span></h4>
+          <div class="grid grid-cols-2 gap-2">
+            <div><label class="text-[10px] text-gray-500">Lucro GV (€)</label><input type="text" id="cfg_med_profit" value="5000" class="w-full rounded border border-white/10 bg-gv-bg text-white text-xs px-2 py-1.5 font-mono" /></div>
+            <div><label class="text-[10px] text-gray-500">Comissão (€)</label><input type="text" id="cfg_med_comm" value="1000" class="w-full rounded border border-white/10 bg-gv-bg text-white text-xs px-2 py-1.5 font-mono" /></div>
+          </div>
+        </div>
+        <!-- Luxury -->
+        <div class="rounded-xl border border-white/[.06] bg-gv-soft/50 p-4">
+          <h4 class="text-sm font-semibold text-amber-400 mb-2">Luxo <span class="text-gray-500 font-normal">(+20.000€)</span></h4>
+          <div class="grid grid-cols-2 gap-2">
+            <div><label class="text-[10px] text-gray-500">Lucro GV (€)</label><input type="text" id="cfg_lux_profit" value="12000" class="w-full rounded border border-white/10 bg-gv-bg text-white text-xs px-2 py-1.5 font-mono" /></div>
+            <div><label class="text-[10px] text-gray-500">Comissão (€)</label><input type="text" id="cfg_lux_comm" value="2000" class="w-full rounded border border-white/10 bg-gv-bg text-white text-xs px-2 py-1.5 font-mono" /></div>
+            <div><label class="text-[10px] text-gray-500">Multi. Marít.</label><input type="text" id="cfg_lux_sea" value="2" class="w-full rounded border border-white/10 bg-gv-bg text-white text-xs px-2 py-1.5 font-mono" /></div>
+            <div><label class="text-[10px] text-gray-500">Multi. Terr.</label><input type="text" id="cfg_lux_land" value="2" class="w-full rounded border border-white/10 bg-gv-bg text-white text-xs px-2 py-1.5 font-mono" /></div>
+            <div class="col-span-2"><label class="text-[10px] text-gray-500">Autogrua (€)</label><input type="text" id="cfg_lux_crane" value="2000" class="w-full rounded border border-white/10 bg-gv-bg text-white text-xs px-2 py-1.5 font-mono" /></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Other -->
+      <div class="flex items-center gap-2 mb-3">
+        <div class="w-1 h-5 rounded bg-amber-400"></div>
+        <h3 class="text-sm font-semibold uppercase tracking-wider text-gray-300">Outros Parâmetros</h3>
+      </div>
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-5">
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">Transporte terrestre base (€)</label>
+          <input type="text" id="cfg_landBase" value="2000" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 font-mono" />
+        </div>
+        <div>
+          <label class="block text-[11px] uppercase tracking-widest text-gray-500 mb-1">Grua extra FR→PT (€)</label>
+          <input type="text" id="cfg_craneFrPt" value="1000" class="w-full rounded-lg border border-white/10 bg-gv-bg text-white text-sm px-3 py-2 font-mono" />
+        </div>
+      </div>
+
+      <button onclick="GV.applySettings()" class="px-6 py-2.5 rounded-xl text-sm font-bold uppercase tracking-wider text-gv-bg transition-all hover:-translate-y-0.5" style="background: linear-gradient(135deg, #00ff88, #4da6ff); box-shadow: 0 10px 30px rgba(0,255,136,0.3);">
+        ✓ Guardar Configurações
+      </button>
+      <span id="cfg_saved" class="ml-3 text-sm text-[#00ff88] hidden">Guardado!</span>
+    </div>
+  </div>
+
+</div>
+
+<!-- ================================================================== -->
+<!-- JAVASCRIPT UNIFICADO -->
+<!-- ================================================================== -->
+<script>
+const GV = (() => {
+  // ============================
+  // STATE
+  // ============================
+  let ACTIVE_COUNTRY = "portugal";
+  const LAND_BASE = () => pn('cfg_landBase') || 2000;
+  const CRANE_FR_PT = () => pn('cfg_craneFrPt') || 1000;
+
+  // ============================
+  // TIERS (read from settings)
+  // ============================
+  function getTiers() {
+    return {
+      low: {
+        id: "low", label: "Low Budget",
+        description: "Casas até 5.000€. Lucro GV + Comissão base. Transporte normal.",
+        companyProfit: pn('cfg_low_profit') || 3000,
+        commission: pn('cfg_low_comm') || 500,
+        landMultiplier: 1, seaMultiplier: 1, craneCost: 0
+      },
+      medium: {
+        id: "medium", label: "Valor Médio",
+        description: "Casas entre 5.000€ e 20.000€. Lucro GV reforçado + Comissão intermédia.",
+        companyProfit: pn('cfg_med_profit') || 5000,
+        commission: pn('cfg_med_comm') || 1000,
+        landMultiplier: 1, seaMultiplier: 1, craneCost: 0
+      },
+      luxury: {
+        id: "luxury", label: "Luxo",
+        description: "Casas acima de 20.000€. Lucro máximo, marítimo x2, terrestre x2 + autogrua.",
+        companyProfit: pn('cfg_lux_profit') || 12000,
+        commission: pn('cfg_lux_comm') || 2000,
+        landMultiplier: pn('cfg_lux_land') || 2,
+        seaMultiplier: pn('cfg_lux_sea') || 2,
+        craneCost: pn('cfg_lux_crane') || 2000
+      }
+    };
+  }
+
+  // ============================
+  // EXCHANGE RATES (from settings)
+  // ============================
+  function getExchangeRates() {
+    const brl = pn('cfg_brl') || 6.5;
+    const cny = pn('cfg_cny') || 8.0;
+    const usd = pn('cfg_usd') || 1.10;
+    const pln = pn('cfg_pln') || 4.5;
+    const gbp = pn('cfg_gbp') || 0.84;
+    return {
+      portugal: { rate: 1, symbol: "€", code: "EUR" },
+      spain: { rate: 1, symbol: "€", code: "EUR" },
+      france: { rate: 1, symbol: "€", code: "EUR" },
+      italy: { rate: 1, symbol: "€", code: "EUR" },
+      greece: { rate: 1, symbol: "€", code: "EUR" },
+      malta: { rate: 1, symbol: "€", code: "EUR" },
+      "netherlands-dest": { rate: 1, symbol: "€", code: "EUR" },
+      poland: { rate: pln, symbol: "zł", code: "PLN" },
+      croatia: { rate: 1, symbol: "€", code: "EUR" },
+      brazil: { rate: brl, symbol: "R$", code: "BRL" },
+      china: { rate: 1, symbol: "€", code: "EUR" },
+      usa: { rate: usd, symbol: "$", code: "USD" }
+    };
+  }
+
+  function getCurrencyRatesToEUR() {
+    const brl = pn('cfg_brl') || 6.5;
+    const cny = pn('cfg_cny') || 8.0;
+    const usd = pn('cfg_usd') || 1.10;
+    const pln = pn('cfg_pln') || 4.5;
+    const gbp = pn('cfg_gbp') || 0.84;
+    return {
+      EUR: 1,
+      GBP: 1 / gbp,
+      BRL: 1 / brl,
+      CNY: 1 / cny,
+      USD: 1 / usd,
+      PLN: 1 / pln
+    };
+  }
+
+  const currencyMeta = {
+    EUR: { symbol: "€" }, GBP: { symbol: "£" }, BRL: { symbol: "R$" },
+    CNY: { symbol: "¥" }, USD: { symbol: "$" }, PLN: { symbol: "zł" }
+  };
+
+  // ============================
+  // TRANSPORT ROUTES (unified)
+  // ============================
+  const transportRoutes = {
+    portugal: {
+      label: "Portugal", flag: "🇵🇹", vatRate: 0.23,
+      routes: {
+        uk: [
+          { from: "Purfleet", to: "Leixões", cost: 3625, type: "RO-RO" },
+          { from: "Killingholme", to: "Leixões", cost: 3975, type: "RO-RO" },
+          { from: "Portbury", to: "Setúbal", cost: 5950, type: "RO-RO" },
+          { from: "Felixstowe", to: "Leixões", cost: 6780, type: "Flat Rack" }
+        ],
+        netherlands: [{ from: "Rotterdam", to: "Leixões", cost: 2400, type: "RO-RO" }],
+        france: [{ from: "França", to: "Portugal", cost: 6000, type: "Camião", isLandRoute: true }],
+        portugal: [
+          { from: "Leixões", to: "Caniçal", cost: 2960, type: "Flat Rack" },
+          { from: "Leixões", to: "Caniçal", cost: 5550, type: "Breakbulk" },
+          { from: "Leixões", to: "Porto Santo", cost: 3790, type: "Flat Rack" },
+          { from: "Leixões", to: "Porto Santo", cost: 6945, type: "Breakbulk" },
+          { from: "Leixões", to: "Ponta Delgada", cost: 6650, type: "Flat Rack" },
+          { from: "Leixões", to: "Ponta Delgada", cost: 8162, type: "Breakbulk" },
+          { from: "Leixões", to: "Ilha do Pico", cost: 6650, type: "Flat Rack" }
+        ],
+        china: [
+          { from: "Shanghai", to: "Leixões", cost: 21000, type: "Flat Rack" },
+          { from: "Shanghai", to: "Leixões", cost: 2655, type: "Container 20'" },
+          { from: "Shanghai", to: "Leixões", cost: 3528, type: "Container 40'" }
+        ]
+      }
+    },
+    spain: {
+      label: "Espanha", flag: "🇪🇸", vatRate: 0.21,
+      routes: {
+        uk: [
+          { from: "Purfleet", to: "Santander", cost: 4950, type: "RO-RO" },
+          { from: "Felixstowe", to: "Algeciras", cost: 5980, type: "Flat Rack" },
+          { from: "Felixstowe", to: "Valencia", cost: 9650, type: "Flat Rack" },
+          { from: "Portbury", to: "Vigo", cost: 11050, type: "RO-RO" },
+          { from: "Southampton", to: "Valencia", cost: 11950, type: "RO-RO" },
+          { from: "Southampton", to: "Santander", cost: 12950, type: "RO-RO" },
+          { from: "Portbury", to: "Sagunto", cost: 16570, type: "RO-RO" }
+        ],
+        netherlands: [
+          { from: "Rotterdam", to: "Valencia", cost: 3500, type: "RO-RO" },
+          { from: "Rotterdam", to: "Santander", cost: 3200, type: "RO-RO" }
+        ],
+        france: [
+          { from: "Calais", to: "Santander", cost: 2800, type: "RO-RO" },
+          { from: "Marseille", to: "Valencia", cost: 2500, type: "RO-RO" }
+        ]
+      }
+    },
+    france: {
+      label: "França", flag: "🇫🇷", vatRate: 0.20,
+      routes: {
+        uk: [
+          { from: "Purfleet", to: "Calais", cost: 2950, type: "RO-RO" },
+          { from: "Tilbury", to: "Le Havre", cost: 3250, type: "RO-RO" },
+          { from: "Southampton", to: "Le Havre", cost: 3750, type: "RO-RO" }
+        ],
+        france: [
+          { from: "Calais", to: "Le Havre", cost: 2500, type: "Camião", isLandRoute: true },
+          { from: "Le Havre", to: "Marseille", cost: 3500, type: "Camião", isLandRoute: true }
+        ]
+      }
+    },
+    italy: { label: "Itália", flag: "🇮🇹", vatRate: 0.22, routes: { uk: [
+      { from: "Southampton", to: "Salerno", cost: 11950, type: "RO-RO" },
+      { from: "Portbury", to: "Livorno", cost: 16010, type: "RO-RO" }
+    ]}},
+    greece: { label: "Grécia", flag: "🇬🇷", vatRate: 0.24, routes: { uk: [
+      { from: "Southampton", to: "Pireu", cost: 13950, type: "RO-RO" },
+      { from: "Southampton", to: "Thessaloniki", cost: 14500, type: "RO-RO" }
+    ]}},
+    malta: { label: "Malta", flag: "🇲🇹", vatRate: 0.18, routes: { uk: [
+      { from: "Southampton", to: "Valletta", cost: 13250, type: "RO-RO" }
+    ]}},
+    "netherlands-dest": { label: "Holanda", flag: "🇳🇱", vatRate: 0.21, routes: {
+      uk: [
+        { from: "Purfleet", to: "Rotterdam", cost: 1325, type: "RO-RO" },
+        { from: "Killingholme", to: "Rotterdam", cost: 1675, type: "RO-RO" }
+      ],
+      france: [{ from: "Calais", to: "Rotterdam", cost: 2800, type: "Camião", isLandRoute: true }]
+    }},
+    poland: { label: "Polónia", flag: "🇵🇱", vatRate: 0.23, routes: {
+      uk: [
+        { from: "Felixstowe", to: "Gdańsk", cost: 6950, type: "Flat Rack" },
+        { from: "Purfleet", to: "Gdansk", cost: 9900, type: "RO-RO" },
+        { from: "Southampton", to: "Gdynia", cost: 11950, type: "RO-RO" }
+      ],
+      netherlands: [{ from: "Rotterdam", to: "Szczecin", cost: 3800, type: "RO-RO" }],
+      france: [{ from: "Calais", to: "Gdansk", cost: 5200, type: "RO-RO" }]
+    }},
+    croatia: { label: "Croácia", flag: "🇭🇷", vatRate: 0.25, routes: { uk: [
+      { from: "Southampton", to: "Rijeka", cost: 11950, type: "RO-RO" },
+      { from: "Southampton", to: "Split", cost: 12950, type: "RO-RO" }
+    ]}},
+    brazil: {
+      label: "Brasil", flag: "🇧🇷", vatRate: 0,
+      // Taxas simplificadas para cálculo rápido internacional
+      brTaxII: 0.126, brTaxIPI: 0, brTaxPIS: 0.021, brTaxCOFINS: 0.0965, brTaxICMS: 0.18,
+      routes: {
+        uk: [
+          { from: "London Gateway", to: "Santos", cost: 13500, type: "Flat Rack" },
+          { from: "Tilbury", to: "Santos", cost: 25200, type: "RO-RO" },
+          { from: "Tilbury", to: "Vitória", cost: 25200, type: "RO-RO" },
+          { from: "Tilbury", to: "Rio de Janeiro", cost: 25200, type: "RO-RO" }
+        ],
+        netherlands: [
+          { from: "Rotterdam", to: "Santos", cost: 13500, type: "Flat Rack" },
+          { from: "Rotterdam", to: "Santos", cost: 25200, type: "RO-RO" },
+          { from: "Rotterdam", to: "Vitória", cost: 25200, type: "RO-RO" },
+          { from: "Rotterdam", to: "Rio de Janeiro", cost: 25200, type: "RO-RO" }
+        ],
+        china: [
+          { from: "Shanghai", to: "Santos", cost: 21000, type: "Flat Rack" },
+          { from: "Shanghai", to: "Santos", cost: 2880, type: "Container 20HQ" },
+          { from: "Shanghai", to: "Santos", cost: 5760, type: "Container 40HQ" }
+        ]
+      }
+    },
+    china: { label: "China → Portugal", flag: "🇨🇳", vatRate: 0.23, vatExtra: 0.027, deliverToEU: true, routes: { china: [
+      { from: "Shanghai", to: "Leixões", cost: 21000, type: "Flat Rack" },
+      { from: "Shanghai", to: "Leixões", cost: 2655, type: "Container 20'" },
+      { from: "Shanghai", to: "Leixões", cost: 3528, type: "Container 40'" }
+    ]}},
+    usa: { label: "EUA", flag: "🇺🇸", vatRate: 0, routes: { uk: [
+      { from: "Southampton", to: "New York, NY", cost: 29550, type: "RO-RO" },
+      { from: "Southampton", to: "Brunswick, GA", cost: 29550, type: "RO-RO" },
+      { from: "Southampton", to: "Galveston, TX", cost: 34370, type: "RO-RO" }
+    ]}}
+  };
+
+  const EU = new Set(["portugal","spain","france","italy","greece","malta","netherlands-dest","poland","croatia"]);
+  const originLabels = { uk: "🇬🇧 Inglaterra", netherlands: "🇳🇱 Holanda", france: "🇫🇷 França", portugal: "🇵🇹 Portugal (ilhas)", china: "🇨🇳 China" };
+
+  // ============================
+  // HELPERS
+  // ============================
+  function pn(id) {
+    const el = document.getElementById(id);
+    if (!el) return 0;
+    const raw = el.value.trim().replace(/\./g, '').replace(',', '.');
+    return parseFloat(raw) || 0;
+  }
+  function fmt(v, locale = "pt-PT") {
+    return new Intl.NumberFormat(locale, { minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(Math.round(v || 0));
+  }
+  function fmtCur(v, sym = "€", locale = "pt-PT") {
+    return `${sym}${fmt(v, locale)}`;
+  }
+
+  // ============================
+  // TAB SWITCHING
+  // ============================
+  function switchTab(tabId) {
+    ['international', 'brazil', 'settings'].forEach(t => {
+      document.getElementById('panel-' + t).classList.toggle('hidden', t !== tabId);
+      document.getElementById('tab-' + t).classList.toggle('tab-active', t === tabId);
+    });
+  }
+
+  // ============================
+  // COUNTRY SELECTION
+  // ============================
+  function buildCountryButtons() {
+    const euEl = document.getElementById('eu-countries');
+    const nonEuEl = document.getElementById('non-eu-countries');
+    const euList = ["portugal","spain","france","italy","greece","malta","netherlands-dest","poland","croatia"];
+    const nonEuList = ["brazil","china","usa"];
+
+    function makeBtn(key) {
+      const cfg = transportRoutes[key];
+      const btn = document.createElement('button');
+      btn.className = 'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-white/[.08] bg-gv-bg text-gray-500 text-[13px] cursor-pointer transition-all hover:border-white/20 hover:bg-gv-soft';
+      btn.dataset.country = key;
+      btn.innerHTML = `<span class="text-lg">${cfg.flag}</span> ${cfg.label}`;
+      btn.onclick = () => selectCountry(key);
+      return btn;
+    }
+    euList.forEach(k => euEl.appendChild(makeBtn(k)));
+    nonEuList.forEach(k => nonEuEl.appendChild(makeBtn(k)));
+  }
+
+  function selectCountry(countryId) {
+    const cfg = transportRoutes[countryId];
+    if (!cfg) return;
+    ACTIVE_COUNTRY = countryId;
+
+    document.querySelectorAll('[data-country]').forEach(btn => {
+      btn.classList.toggle('country-active', btn.dataset.country === countryId);
+    });
+
+    document.getElementById('intl_flag').textContent = cfg.flag;
+    document.getElementById('intl_countryLabel').textContent = cfg.label;
+
+    populateOrigins(countryId);
+    updateRoutes();
+    updateTierPreview();
+
+    document.getElementById('intl_results').classList.add('hidden');
+  }
+
+  function populateOrigins(countryId) {
+    const cfg = transportRoutes[countryId];
+    const sel = document.getElementById('intl_origin');
+    sel.innerHTML = '';
+    if (!cfg?.routes) return;
+    Object.keys(cfg.routes).forEach(k => {
+      const opt = document.createElement('option');
+      opt.value = k;
+      opt.textContent = originLabels[k] || k;
+      sel.appendChild(opt);
+    });
+  }
+
+  function updateRoutes() {
+    const cfg = transportRoutes[ACTIVE_COUNTRY];
+    const origin = document.getElementById('intl_origin').value;
+    const sel = document.getElementById('intl_route');
+    sel.innerHTML = '';
+    if (!cfg?.routes?.[origin]) return;
+    cfg.routes[origin].forEach((r, i) => {
+      const opt = document.createElement('option');
+      opt.value = i;
+      opt.textContent = `${r.from} → ${r.to} • ${r.type} • €${r.cost.toLocaleString("pt-PT")}`;
+      sel.appendChild(opt);
+    });
+  }
+
+  function determineTier(priceEUR) {
+    if (!priceEUR || priceEUR <= 0) return "medium";
+    if (priceEUR <= 5000) return "low";
+    if (priceEUR > 20000) return "luxury";
+    return "medium";
+  }
+
+  function updateTierPreview() {
+    const price = parseFloat(document.getElementById('intl_price').value) || 0;
+    const currency = document.getElementById('intl_currency').value;
+    const rates = getCurrencyRatesToEUR();
+    const priceEUR = price * (rates[currency] || 1);
+    const tierId = determineTier(priceEUR);
+    const tiers = getTiers();
+    const tier = tiers[tierId];
+    document.getElementById('intl_tierPill').textContent = tier.label;
+    document.getElementById('intl_tierDesc').textContent = tier.description;
+  }
+
+  // ============================
+  // CALC: INTERNATIONAL
+  // ============================
+  function calcInternational() {
+    const cfg = transportRoutes[ACTIVE_COUNTRY];
+    if (!cfg) return;
+
+    const inputPrice = parseFloat(document.getElementById('intl_price').value) || 0;
+    const currencyCode = document.getElementById('intl_currency').value;
+    const originKey = document.getElementById('intl_origin').value;
+    const routeIdx = parseInt(document.getElementById('intl_route').value, 10);
+    const routes = cfg.routes?.[originKey] || [];
+
+    if (isNaN(routeIdx) || routeIdx >= routes.length) { alert("Seleciona uma rota."); return; }
+    const route = routes[routeIdx];
+
+    const exchangeRates = getExchangeRates();
+    const ratesEUR = getCurrencyRatesToEUR();
+    const tiers = getTiers();
+
+    const isEU = EU.has(ACTIVE_COUNTRY);
+    const isBrazil = ACTIVE_COUNTRY === "brazil";
+    const isChina = ACTIVE_COUNTRY === "china";
+    // FIX: China destination delivers to EU (Portugal) - needs IVA final
+    const deliverToEU = isEU || (cfg.deliverToEU === true);
+
+    const priceEUR = inputPrice * (ratesEUR[currencyCode] || 1);
+    const tierId = determineTier(priceEUR);
+    const tier = tiers[tierId];
+
+    document.getElementById('intl_tierPill').textContent = tier.label;
+    document.getElementById('intl_tierDesc').textContent = tier.description;
+
+    const PROFIT = tier.companyProfit;
+    const COMM = tier.commission;
+
+    // FIX: For land routes (e.g. France→Portugal by truck), the route cost is land transport, not sea
+    const isLandRoute = route.isLandRoute === true;
+    let seaCost = isLandRoute ? 0 : route.cost * tier.seaMultiplier;
+    let landCost = 0;
+
+    if (isLandRoute) {
+      // The route cost IS the land transport cost
+      landCost = route.cost * tier.landMultiplier;
+    } else if (ACTIVE_COUNTRY === "portugal" && originKey === "france") {
+      // Legacy: France→Portugal was treated as land, keep backward compat
+      landCost = 0;
+    } else {
+      landCost = LAND_BASE() * tier.landMultiplier;
+    }
+
+    let extraCrane = 0;
+    if (ACTIVE_COUNTRY === "portugal" && originKey === "france") {
+      extraCrane = CRANE_FR_PT();
+    }
+    const craneCost = tier.craneCost + extraCrane;
+
+    let price = priceEUR;
+    let vatImport = 0;
+    let vatExtraImport = 0;
+    let subtotalSemIVA = 0;
+
+    // Brazil-specific tax variables
+    let cifValue = 0;
+    let valorII = 0, valorIPI = 0, valorPIS = 0, valorCOFINS = 0, valorICMS = 0;
+    let totalTaxesBR = 0;
+
+    if (isBrazil) {
+      // FIX: CIF = price + sea freight (standard Incoterms)
+      cifValue = price + seaCost;
+
+      // FIX: Full Brazilian tax cascade matching the detailed tab
+      const iiRate = cfg.brTaxII || 0;
+      const ipiRate = cfg.brTaxIPI || 0;
+      const pisRate = cfg.brTaxPIS || 0;
+      const cofinsRate = cfg.brTaxCOFINS || 0;
+      const icmsRate = cfg.brTaxICMS || 0;
+
+      // II sobre CIF
+      valorII = cifValue * iiRate;
+      // IPI sobre CIF + II
+      valorIPI = (cifValue + valorII) * ipiRate;
+      // PIS sobre CIF + II + IPI
+      valorPIS = (cifValue + valorII + valorIPI) * pisRate;
+      // COFINS sobre CIF + II + IPI
+      valorCOFINS = (cifValue + valorII + valorIPI) * cofinsRate;
+      // ICMS com gross-up: base = (CIF+II+IPI+PIS+COFINS) / (1 - icmsRate)
+      const icmsDivisor = (1 - icmsRate) || 1;
+      const baseICMS = (cifValue + valorII + valorIPI + valorPIS + valorCOFINS) / icmsDivisor;
+      valorICMS = baseICMS * icmsRate;
+
+      totalTaxesBR = valorII + valorIPI + valorPIS + valorCOFINS + valorICMS;
+      subtotalSemIVA = price + seaCost + landCost + craneCost + totalTaxesBR + PROFIT + COMM;
+
+    } else if (isChina) {
+      // China → Portugal: import VAT applied on (price + sea)
+      const base = price + seaCost;
+      vatImport = base * (cfg.vatRate || 0);
+      if (cfg.vatExtra) vatExtraImport = base * cfg.vatExtra;
+      // FIX: these are import duties, not final IVA. Subtotal does NOT include final IVA.
+      subtotalSemIVA = price + seaCost + vatImport + vatExtraImport + landCost + craneCost + PROFIT + COMM;
+
+    } else {
+      // EU and other destinations
+      if (originKey === "uk" || originKey === "china") {
+        // Import from outside EU: import VAT on goods + sea freight
+        const base = price + seaCost;
+        vatImport = base * (cfg.vatRate || 0.23);
+        // FIX: vatImport is the import duty, included in subtotal.
+        // The final IVA is calculated separately and does NOT include vatImport to avoid double taxation.
+        subtotalSemIVA = price + seaCost + vatImport + landCost + craneCost + PROFIT + COMM;
+      } else {
+        // Intra-EU: no import duties
+        subtotalSemIVA = price + seaCost + landCost + craneCost + PROFIT + COMM;
+      }
+    }
+
+    // FIX: IVA final only on the commercial margin (profit + commission + land transport),
+    // not on the entire subtotal which already includes import VAT.
+    // For EU destinations (including China→Portugal which delivers to EU):
+    let ivaFinalRate = deliverToEU ? (cfg.vatRate || 0) : 0;
+    let ivaFinal = 0;
+
+    if (deliverToEU && ivaFinalRate > 0) {
+      if (originKey === "uk" || originKey === "china" || isChina) {
+        // Import scenario: IVA already paid on import (vatImport).
+        // Final IVA applies on the sale price excluding already-paid import VAT.
+        const baseForFinalIVA = subtotalSemIVA - vatImport - vatExtraImport;
+        ivaFinal = baseForFinalIVA * ivaFinalRate;
+      } else {
+        // Intra-EU: full IVA on subtotal
+        ivaFinal = subtotalSemIVA * ivaFinalRate;
+      }
+    }
+
+    const totalComIVA = subtotalSemIVA + ivaFinal;
+
+    const localCfg = exchangeRates[ACTIVE_COUNTRY] || { rate: 1, symbol: "€", code: "EUR" };
+    const totalLocal = totalComIVA * localCfg.rate;
+
+    // RENDER
+    const grid = document.getElementById('intl_grid');
+    grid.innerHTML = '';
+
+    function card(label, value, opts = {}) {
+      const cls = [
+        'rounded-xl border border-white/[.06] p-3 text-sm',
+        opts.full ? 'sm:col-span-2' : '',
+        opts.highlight ? 'result-highlight' : 'bg-gradient-to-br from-gv-soft to-gv-bg'
+      ].join(' ');
+      grid.innerHTML += `<div class="${cls}">
+        <div class="text-[10px] uppercase tracking-[0.13em] text-gray-500 mb-1">${label}</div>
+        <div class="font-semibold ${opts.final ? 'text-base' : ''}">${value}</div>
+      </div>`;
+    }
+
+    const sym = (currencyMeta[currencyCode] || {}).symbol || '';
+    card("Escala aplicada", tier.label, { full: true });
+
+    if (inputPrice > 0) {
+      card("Preço casa (origem)", `${sym}${inputPrice.toLocaleString("pt-PT")}`);
+      if (currencyCode !== "EUR") card("Preço em EUR", fmtCur(price));
+    }
+
+    // FIX: correct label for land vs sea routes
+    if (isLandRoute) {
+      card(`Transporte terrestre (${route.type})`, fmtCur(landCost));
+    } else {
+      card(`Marítimo (${route.type})`, fmtCur(seaCost));
+      if (landCost > 0) card("Terrestre no destino", fmtCur(landCost));
+    }
+
+    if (craneCost > 0) card("Grua / Autogrua", fmtCur(craneCost));
+
+    if (isBrazil) {
+      // FIX: correct labels matching actual tax names
+      card("CIF (Casa + Frete Marítimo)", fmtCur(cifValue));
+      card(`II (${(cfg.brTaxII * 100).toFixed(1).replace('.', ',')}%)`, fmtCur(valorII));
+      if (valorIPI > 0) card(`IPI (${(cfg.brTaxIPI * 100).toFixed(1).replace('.', ',')}%)`, fmtCur(valorIPI));
+      card(`PIS (${(cfg.brTaxPIS * 100).toFixed(1).replace('.', ',')}%)`, fmtCur(valorPIS));
+      card(`COFINS (${(cfg.brTaxCOFINS * 100).toFixed(1).replace('.', ',')}%)`, fmtCur(valorCOFINS));
+      card(`ICMS gross-up (${(cfg.brTaxICMS * 100).toFixed(0)}%)`, fmtCur(valorICMS));
+      card("Total impostos BR", fmtCur(totalTaxesBR));
+    }
+
+    if (vatImport > 0) {
+      const vatPct = isChina ? (cfg.vatRate || 0) : (cfg.vatRate || 0.23);
+      card(`IVA importação (${Math.round(vatPct * 100)}%)`, fmtCur(vatImport));
+    }
+    if (vatExtraImport > 0) card("Taxa adicional 2,7%", fmtCur(vatExtraImport));
+
+    card("Lucro Green Village", fmtCur(PROFIT));
+    card("Comissão vendedor", fmtCur(COMM));
+    card("Total SEM IVA final", fmtCur(subtotalSemIVA), { full: true, final: true });
+
+    if (ivaFinalRate > 0) {
+      const ivaPct = (ivaFinalRate * 100).toFixed(0);
+      card(`IVA final (${ivaPct}%)`, fmtCur(ivaFinal));
+    }
+
+    card("TOTAL COM IVA", fmtCur(totalComIVA), { full: true, highlight: true, final: true });
+
+    if (localCfg.code !== "EUR") {
+      card(`Total em ${localCfg.code}`, `${localCfg.symbol}${fmt(totalLocal)}`, { full: true, highlight: true, final: true });
+    }
+
+    card("Rota", `${route.from} → ${route.to} (${route.type})`, { full: true });
+
+    document.getElementById('intl_results').classList.remove('hidden');
+  }
+
+  // ============================
+  // CALC: BRAZIL DETAILED
+  // ============================
+  function calcBrazil() {
+    const fobUsd = pn('br_fobUsd');
+    const freightUsd = pn('br_freightUsd');
+    const insuranceUsd = pn('br_insuranceUsd');
+    const exchangeRate = pn('br_exchangeRate') || pn('cfg_usdbrl') || 6;
+
+    const fobBrl = fobUsd * exchangeRate;
+    const freightBrl = freightUsd * exchangeRate;
+    const insuranceBrl = insuranceUsd * exchangeRate;
+    const cifBrl = fobBrl + freightBrl + insuranceBrl;
+
+    const isBk = document.getElementById('br_isBk').checked;
+    const iiRate = (isBk ? pn('br_iiRateBk') : pn('br_iiRateNonBk')) / 100;
+    const ipiRate = pn('br_ipiRate') / 100;
+    const pisRate = pn('br_pisRate') / 100;
+    const cofinsRate = pn('br_cofinsRate') / 100;
+    const icmsRate = pn('br_icmsRate') / 100;
+
+    const valorII = cifBrl * iiRate;
+    const baseIPI = cifBrl + valorII;
+    const valorIPI = baseIPI * ipiRate;
+    const basePisCofins = cifBrl + valorII + valorIPI;
+    const valorPIS = basePisCofins * pisRate;
+    const valorCOFINS = basePisCofins * cofinsRate;
+
+    const divisor = (1 - icmsRate) || 1;
+    const baseICMS = (cifBrl + valorII + valorIPI + valorPIS + valorCOFINS) / divisor;
+    const valorICMS = baseICMS * icmsRate;
+
+    const totalTributos = valorII + valorIPI + valorPIS + valorCOFINS + valorICMS;
+    const cargaEfetiva = cifBrl > 0 ? (totalTributos / cifBrl) * 100 : 0;
+
+    const portCosts = pn('br_portCosts');
+    const inlandTransport = pn('br_inlandTransport');
+    const custoTotal = cifBrl + totalTributos + portCosts + inlandTransport;
+
+    const marginPercent = pn('br_marginPercent');
+    const valorLucro = custoTotal * (marginPercent / 100);
+    const precoFinal = custoTotal + valorLucro;
+
+    const f = v => fmtCur(v, "R$", "pt-BR");
+
+    function row(label, value, bold = false) {
+      return `<div class="flex justify-between py-1 ${bold ? 'pt-2 mt-1 border-t border-white/[.06]' : ''}">
+        <span class="text-gray-500 text-xs">${label}</span>
+        <span class="${bold ? 'text-[#00ff88] font-bold' : 'font-medium'} text-sm font-mono">${value}</span>
+      </div>`;
+    }
+
+    document.getElementById('br_importSummary').innerHTML =
+      row("FOB (BRL)", f(fobBrl)) +
+      row("Frete Marítimo (BRL)", f(freightBrl)) +
+      row("Seguro (BRL)", f(insuranceBrl)) +
+      row("Valor CIF (BRL)", f(cifBrl), true) +
+      `<div class="my-2 border-t border-white/[.06]"></div>` +
+      row("II", f(valorII)) +
+      row("IPI", f(valorIPI)) +
+      row("PIS", f(valorPIS)) +
+      row("COFINS", f(valorCOFINS)) +
+      row("ICMS (gross-up)", f(valorICMS)) +
+      row("Total Tributos", f(totalTributos), true) +
+      row("Carga tributária efetiva", `${cargaEfetiva.toFixed(1).replace('.', ',')}%`);
+
+    document.getElementById('br_priceFormation').innerHTML =
+      row("Valor CIF", f(cifBrl)) +
+      row("Total Tributos", f(totalTributos)) +
+      row("Custos Portuários", f(portCosts)) +
+      row("Transporte Terrestre", f(inlandTransport)) +
+      row("Custo Nacionalizado", f(custoTotal), true) +
+      `<div class="my-2 border-t border-white/[.06]"></div>` +
+      row(`Mark-up (${marginPercent}%)`, f(valorLucro)) +
+      row("PREÇO DE VENDA", f(precoFinal), true);
+
+    document.getElementById('br_results').classList.remove('hidden');
+  }
+
+  // ============================
+  // SETTINGS
+  // ============================
+  function applySettings() {
+    updateTierPreview();
+    const msg = document.getElementById('cfg_saved');
+    msg.classList.remove('hidden');
+    setTimeout(() => msg.classList.add('hidden'), 2000);
+  }
+
+  // ============================
+  // EXCHANGE RATE FETCH
+  // ============================
+  async function fetchRates() {
+    const status = document.getElementById('rateStatus');
+    status.textContent = "Câmbio: a carregar...";
+    status.classList.add('pulse-rate');
+    try {
+      const pairs = ["USD-EUR","GBP-EUR","BRL-EUR","CNY-EUR","PLN-EUR","USD-BRL"];
+      const resp = await fetch(`https://economia.awesomeapi.com.br/json/last/${pairs.join(',')}`);
+      const data = await resp.json();
+
+      // FIX: consistent precision (4 decimals for all rates)
+      if (data.USDEUR) document.getElementById('cfg_usd').value = (1 / parseFloat(data.USDEUR.bid)).toFixed(4);
+      if (data.GBPEUR) document.getElementById('cfg_gbp').value = (1 / parseFloat(data.GBPEUR.bid)).toFixed(4);
+      if (data.BRLEUR) document.getElementById('cfg_brl').value = (1 / parseFloat(data.BRLEUR.bid)).toFixed(4);
+      if (data.CNYEUR) document.getElementById('cfg_cny').value = (1 / parseFloat(data.CNYEUR.bid)).toFixed(4);
+      if (data.PLNEUR) document.getElementById('cfg_pln').value = (1 / parseFloat(data.PLNEUR.bid)).toFixed(4);
+      if (data.USDBRL) {
+        document.getElementById('cfg_usdbrl').value = parseFloat(data.USDBRL.bid).toFixed(4);
+        document.getElementById('br_exchangeRate').value = parseFloat(data.USDBRL.bid).toFixed(4);
+      }
+
+      status.textContent = `Câmbio: atualizado (${new Date().toLocaleTimeString("pt-PT")})`;
+      status.classList.remove('pulse-rate');
+      status.style.borderColor = 'rgba(0,255,136,0.3)';
+      status.style.color = '#00ff88';
+    } catch (e) {
+      status.textContent = "Câmbio: erro na API";
+      status.classList.remove('pulse-rate');
+      status.style.color = '#f87171';
+    }
+  }
+
+  // ============================
+  // PDF EXPORT
+  // ============================
+  async function exportPDF(containerId, title) {
+    const el = document.getElementById(containerId);
+    if (!el) return;
+    try {
+      const canvas = await html2canvas(el, {
+        backgroundColor: '#0b0f17',
+        scale: 2,
+        useCORS: true
+      });
+      const { jsPDF } = window.jspdf;
+      const pdf = new jsPDF('p', 'mm', 'a4');
+      const imgData = canvas.toDataURL('image/png');
+      const pdfW = pdf.internal.pageSize.getWidth();
+      const pdfH = (canvas.height * pdfW) / canvas.width;
+
+      pdf.setFillColor(11, 15, 23);
+      pdf.rect(0, 0, pdfW, pdf.internal.pageSize.getHeight(), 'F');
+
+      pdf.setTextColor(0, 255, 136);
+      pdf.setFontSize(14);
+      pdf.text(`Green Village — ${title}`, 10, 12);
+      pdf.setTextColor(156, 162, 184);
+      pdf.setFontSize(8);
+      pdf.text(`Gerado em: ${new Date().toLocaleString("pt-PT")}`, 10, 18);
+
+      pdf.addImage(imgData, 'PNG', 5, 22, pdfW - 10, pdfH - 10);
+      pdf.save(`GreenVillage_${title}_${Date.now()}.pdf`);
+    } catch (e) {
+      alert("Erro ao gerar PDF. Verifique se os scripts estão carregados.");
+      console.error(e);
+    }
+  }
+
+  // ============================
+  // INIT
+  // ============================
+  function init() {
+    buildCountryButtons();
+    selectCountry("portugal");
+
+    // FIX: attach event listeners for price and currency changes
+    document.getElementById('intl_price').addEventListener('input', updateTierPreview);
+    document.getElementById('intl_currency').addEventListener('change', updateTierPreview);
+    document.getElementById('intl_origin').addEventListener('change', () => { updateRoutes(); updateTierPreview(); });
+    // FIX: also update route display when route selector changes (for label updates)
+    document.getElementById('intl_route').addEventListener('change', updateTierPreview);
+
+    // Try auto-fetch rates
+    fetchRates();
+  }
+
+  return {
+    switchTab, calcInternational, calcBrazil, applySettings, fetchRates, exportPDF, init
+  };
+})();
+
+window.addEventListener('DOMContentLoaded', GV.init);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Correções críticas:
- Taxas brasileiras: labels corrigidos (PIS/COFINS→PIS, ICMS→COFINS separados)
- ICMS agora calculado com gross-up correto: base/(1-alíquota)
- IPI incluído na cadeia de impostos do cálculo internacional
- CIF corrigido: preço + frete marítimo (sem FOB artificial de 10%)

Correções médias:
- IVA duplo eliminado: import VAT não é re-tributado no IVA final
- China destino: label "China → Portugal", deliverToEU=true para IVA correto
- Rotas terrestres (França→PT, Calais→Rotterdam): flag isLandRoute evita usar seaCost para transporte por camião
- Precisão câmbio: todas as taxas agora com 4 casas decimais

Correções menores:
- Event listener adicionado no selector de rotas
- Labels dinâmicos com percentagens reais dos impostos
- Versão atualizada para v3.1

https://claude.ai/code/session_01WtEs983bot7jYStLy54n2Z